### PR TITLE
Fix test paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Then
 ```bash
 python test.py
 ```
+The script uses the example LEF and DEF files provided in the `test` directory:
+`NanGate_15nm_UTDA.tech.lef` and `simple.def`.
 ## Usage
 
 To use the LEF reader, you can follow the example provided in the `test.py` file:

--- a/test.py
+++ b/test.py
@@ -1,10 +1,11 @@
 from lefdef import C_LefReader
 from lefdef import C_DefReader
-#change the file address below
+
+# Example usage with the sample files shipped in the ``test`` directory
 lef_reader = C_LefReader()
-_lef = lef_reader.read("external/def/TEST/complete.5.8.def")
+_lef = lef_reader.read("test/NanGate_15nm_UTDA.tech.lef")
 _lef.print()
 
 def_reader = C_DefReader()
-_def = def_reader.read("external/lef/TEST/complete.5.8.lef")
+_def = def_reader.read("test/simple.def")
 _def.print()


### PR DESCRIPTION
## Summary
- update the default file paths in `test.py`
- clarify in README which LEF/DEF examples are used by `test.py`

## Testing
- `python -m py_compile test.py`