### PR TITLE
Add output export for LEF/DEF demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Then
 ```bash
 python test.py
 ```
+The script uses the example LEF and DEF files provided in the `test` directory:
+`NanGate_15nm_UTDA.tech.lef` and `simple.def`.
 ## Usage
 
 To use the LEF reader, you can follow the example provided in the `test.py` file:

--- a/test.py
+++ b/test.py
@@ -1,10 +1,34 @@
 from lefdef import C_LefReader
 from lefdef import C_DefReader
-#change the file address below
+
+import sys
+from contextlib import redirect_stdout
+
+
+class Tee:
+    """Helper class to duplicate output to stdout and a file."""
+
+    def __init__(self, *files):
+        self.files = files
+
+    def write(self, data):
+        for f in self.files:
+            f.write(data)
+
+    def flush(self):
+        for f in self.files:
+            f.flush()
+
+
+# Example usage with the sample files shipped in the ``test`` directory
 lef_reader = C_LefReader()
-_lef = lef_reader.read("external/def/TEST/complete.5.8.def")
-_lef.print()
+_lef = lef_reader.read("test/NanGate_15nm_UTDA.tech.lef")
 
 def_reader = C_DefReader()
-_def = def_reader.read("external/lef/TEST/complete.5.8.lef")
-_def.print()
+_def = def_reader.read("test/simple.def")
+
+# Export the printed output of the LEF and DEF objects to ``output.txt``
+with open("output.txt", "w") as f:
+    with redirect_stdout(Tee(sys.stdout, f)):
+        _lef.print()
+        _def.print()


### PR DESCRIPTION
## Summary
- add a Tee helper to write output to both stdout and a file
- capture LEF/DEF print output in test.py

## Testing
- `python -m py_compile test.py`
- `pytest -q`